### PR TITLE
adds copypaste-warning style for red border around certain blocks

### DIFF
--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -21,6 +21,10 @@ div.listingblock.copypaste div.content pre.highlight:hover code {
     background-repeat: no-repeat;
 }
 
+div.listingblock.copypaste-warning div.content pre.CodeRay.highlight {
+    border: 1px solid #FF0000
+}
+
 div.admonitionblock div.listingblock {
     width: 650px;
 }


### PR DESCRIPTION
In reference to #62 

The PR I submitted adds a new css class of `copypaste-warning` which adds the red border around code blocks that have that role assigned.

Since the copypaste functionality breaks the existing workshop red-border copypaste role, it doesn't matter that this is a new role. Someone would need to update their lab guide to "fix" their copypaste blocks to be warnings anyway.

Note that use of this requires asciidoctor syntax like the following:

`[source,none,role="copypaste copypaste-warning"]`

The above syntax, when processed by workshopper, will result in the css class on the div being `...copypaste copypaste-warning` which causes both classes (`copypaste` and `copypaste-warning`) to be applied.